### PR TITLE
Andriel/items_quantity_columns_and_functions

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/ItemController.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/ItemController.java
@@ -2,8 +2,6 @@ package com.ufrn.nei.almoxarifadoapi.controller;
 
 import java.util.List;
 
-import com.ufrn.nei.almoxarifadoapi.exception.CreateEntityException;
-import com.ufrn.nei.almoxarifadoapi.exception.EntityNotFoundException;
 import com.ufrn.nei.almoxarifadoapi.infra.RestErrorMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,91 +16,83 @@ import org.springframework.web.bind.annotation.*;
 import com.ufrn.nei.almoxarifadoapi.dto.item.ItemCreateDTO;
 import com.ufrn.nei.almoxarifadoapi.dto.item.ItemResponseDTO;
 import com.ufrn.nei.almoxarifadoapi.dto.item.ItemUpdateDTO;
+import com.ufrn.nei.almoxarifadoapi.dto.other.QuantityUpdateDTO;
 import com.ufrn.nei.almoxarifadoapi.service.ItemService;
 
 import jakarta.validation.Valid;
 
-
-@Tag(name = "Itens",
-        description = "Contém todas as operações relativas aos recursos para criação, edição, leitura e exclusão de um item"
-)
+@Tag(name = "Itens", description = "Contém todas as operações relativas aos recursos para criação, edição, leitura e exclusão de um item")
 @RestController
 @RequestMapping("api/v1/itens")
 public class ItemController {
-    @Autowired
-    private ItemService itemService;
+        @Autowired
+        private ItemService itemService;
 
-    @Operation(summary = "Buscar todos os itens", description = "Listará todos os itens cadastrados",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Itens encontrados com sucesso",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class)))
-            }
-    )
-    @GetMapping
-    public ResponseEntity<List<ItemResponseDTO>> getAllItems() {
-        List<ItemResponseDTO> items = itemService.findAllItems();
+        @Operation(summary = "Buscar todos os itens", description = "Listará todos os itens cadastrados", responses = {
+                        @ApiResponse(responseCode = "200", description = "Itens encontrados com sucesso", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class)))
+        })
+        @GetMapping
+        public ResponseEntity<List<ItemResponseDTO>> getAllItems() {
+                List<ItemResponseDTO> items = itemService.findAllItems();
 
-        return ResponseEntity.status(HttpStatus.OK).body(items);
-    }
+                return ResponseEntity.status(HttpStatus.OK).body(items);
+        }
 
-    @Operation(summary = "Buscar itens pelo ID.", description = "Listará o item encontrado com o ID informado.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Item encontrado com sucesso.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
-                    @ApiResponse(responseCode = "400", description = "Item não foi encontrado.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
-            }
-    )
-    @GetMapping("/{id}")
-    public ResponseEntity<ItemResponseDTO> getItem(@PathVariable Long id) {
-        ItemResponseDTO item = itemService.findItem(id);
+        @Operation(summary = "Buscar itens pelo ID.", description = "Listará o item encontrado com o ID informado.", responses = {
+                        @ApiResponse(responseCode = "200", description = "Item encontrado com sucesso.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "Item não foi encontrado.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
+        })
+        @GetMapping("/{id}")
+        public ResponseEntity<ItemResponseDTO> getItem(@PathVariable Long id) {
+                ItemResponseDTO item = itemService.findItem(id);
 
-        return ResponseEntity.status(HttpStatus.OK).body(item);
-    }
+                return ResponseEntity.status(HttpStatus.OK).body(item);
+        }
 
-    @Operation(summary = "Cadastrar novos itens.", description = "Cadastrará novos itens no sistema.",
-            responses = {
-                    @ApiResponse(responseCode = "201", description = "Item cadastrado com sucesso.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
-                    @ApiResponse(responseCode = "400", description = "Não foi possível cadastrar o item.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
-            }
-    )
-    @PostMapping
-    public ResponseEntity<ItemResponseDTO> createItem(@RequestBody ItemCreateDTO itemDTO) {
-        ItemResponseDTO item = itemService.createItem(itemDTO);
+        @Operation(summary = "Cadastrar novos itens.", description = "Cadastrará novos itens no sistema.", responses = {
+                        @ApiResponse(responseCode = "201", description = "Item cadastrado com sucesso.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "Não foi possível cadastrar o item.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
+        })
+        @PostMapping
+        public ResponseEntity<ItemResponseDTO> createItem(@RequestBody @Valid ItemCreateDTO itemDTO) {
+                ItemResponseDTO item = itemService.createItem(itemDTO);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(item);
-    }
+                return ResponseEntity.status(HttpStatus.CREATED).body(item);
+        }
 
-    @Operation(summary = "Atualizar itens cadastrados.", description = "Atualizará as informações do item específicado.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Item atualizado com sucesso.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
-                    @ApiResponse(responseCode = "400", description = "O item especificado não foi encontrado.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
-            }
-    )
-    @PutMapping("/{id}")
-    public ResponseEntity<ItemResponseDTO> updateItem(@PathVariable Long id, @RequestBody @Valid ItemUpdateDTO itemDTO) {
-        ItemResponseDTO item = itemService.updateItem(id, itemDTO);
+        @Operation(summary = "Atualizar itens cadastrados.", description = "Atualizará as informações do item específicado.", responses = {
+                        @ApiResponse(responseCode = "200", description = "Item atualizado com sucesso.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "O item especificado não foi encontrado.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
+        })
+        @PutMapping("/{id}")
+        public ResponseEntity<ItemResponseDTO> updateItem(@PathVariable Long id,
+                        @RequestBody @Valid ItemUpdateDTO itemDTO) {
+                ItemResponseDTO item = itemService.updateItem(id, itemDTO);
 
-        return ResponseEntity.status(HttpStatus.OK).body(item);
-    }
+                return ResponseEntity.status(HttpStatus.OK).body(item);
+        }
 
-    @Operation(summary = "Deletar itens cadastrados.", description = "Excluirá o item especificado.",
-            responses = {
-                    @ApiResponse(responseCode = "204", description = "Item deletado com sucesso.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
-                    @ApiResponse(responseCode = "400", description = "O item especificado não foi encontrado.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
-            }
-    )
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteItem(@PathVariable Long id) {
-        itemService.deleteItem(id);
+        @PutMapping("/lend/{id}")
+        public ResponseEntity<ItemResponseDTO> updateItemQuantity(@PathVariable Long id,
+                        @RequestBody @Valid QuantityUpdateDTO dto) {
+                ItemResponseDTO item;
+                if (dto.getToLend()) {
+                        item = itemService.sumLendQuantity(id, dto.getItems());
+                } else {
+                        item = itemService.subtractLendQuantity(id, dto.getItems());
+                }
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
+                return ResponseEntity.status(HttpStatus.OK).body(item);
+        }
+
+        @Operation(summary = "Deletar itens cadastrados.", description = "Excluirá o item especificado.", responses = {
+                        @ApiResponse(responseCode = "204", description = "Item deletado com sucesso.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ItemResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "O item especificado não foi encontrado.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
+        })
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Void> deleteItem(@PathVariable Long id) {
+                itemService.deleteItem(id);
+
+                return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
 }
-

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemCreateDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemCreateDTO.java
@@ -1,6 +1,7 @@
 package com.ufrn.nei.almoxarifadoapi.dto.item;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,13 +17,19 @@ import java.util.Objects;
 public class ItemCreateDTO {
     @NotBlank
     String name;
+    @NotNull
     @Positive
     Long itemTagging;
+    @NotNull
+    @Positive
+    int quantityAvailable;
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         ItemCreateDTO that = (ItemCreateDTO) o;
         return Objects.equals(name, that.name) && Objects.equals(itemTagging, that.itemTagging);
     }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemResponseDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemResponseDTO.java
@@ -17,7 +17,8 @@ public class ItemResponseDTO {
     public Long id;
     public String name;
     public Long itemTagging;
-    public boolean available;
+    public int quantityAvailable;
+    public int quantityLend;
     public Timestamp createdAt;
     public Timestamp updatedAt;
     public boolean active;
@@ -29,13 +30,13 @@ public class ItemResponseDTO {
         if (o == null || getClass() != o.getClass())
             return false;
         ItemResponseDTO that = (ItemResponseDTO) o;
-        return available == that.available && Objects.equals(id, that.id) && Objects.equals(name, that.name)
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name)
                 && Objects.equals(itemTagging, that.itemTagging);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, itemTagging, available);
+        return Objects.hash(id, name, itemTagging);
     }
 
     @Override
@@ -44,7 +45,6 @@ public class ItemResponseDTO {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", itemTagging=" + itemTagging +
-                ", available=" + available +
                 '}';
     }
 }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemUpdateDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemUpdateDTO.java
@@ -19,11 +19,15 @@ public class ItemUpdateDTO {
     String name;
     @Positive
     Long itemTagging;
+    @Positive
+    int quantityLend;
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         ItemUpdateDTO that = (ItemUpdateDTO) o;
         return Objects.equals(name, that.name) && Objects.equals(itemTagging, that.itemTagging);
     }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/other/QuantityUpdateDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/other/QuantityUpdateDTO.java
@@ -1,0 +1,17 @@
+package com.ufrn.nei.almoxarifadoapi.dto.other;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class QuantityUpdateDTO {
+    @Positive
+    private Integer items;
+    @NotNull
+    private Boolean toLend;
+}

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/entity/ItemEntity.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/entity/ItemEntity.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "Itens")
+@Table(name = "itens")
 public class ItemEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,8 +30,11 @@ public class ItemEntity implements Serializable {
     @Column(name = "tombamento", nullable = false, unique = true)
     private Long itemTagging;
 
-    @Column(name = "disponivel", nullable = false, unique = false)
-    private Boolean available = Boolean.TRUE;
+    @Column(name = "quantidade_disponiveis", nullable = false)
+    private int quantityAvailable;
+
+    @Column(name = "quantidade_emprestados", nullable = false)
+    private int quantityLend;
 
     @Column(name = "criado_em", nullable = false)
     private Timestamp createdAt = Timestamp.valueOf(LocalDateTime.now());
@@ -53,12 +56,12 @@ public class ItemEntity implements Serializable {
             return false;
         ItemEntity that = (ItemEntity) o;
         return Objects.equals(id, that.id) && Objects.equals(name, that.name)
-                && Objects.equals(itemTagging, that.itemTagging) && Objects.equals(available, that.available);
+                && Objects.equals(itemTagging, that.itemTagging);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, itemTagging, available);
+        return Objects.hash(id, name, itemTagging);
     }
 
     @Override
@@ -67,7 +70,6 @@ public class ItemEntity implements Serializable {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", itemTagging=" + itemTagging +
-                ", available=" + available +
                 '}';
     }
 }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/exception/NotAvailableQuantity.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/exception/NotAvailableQuantity.java
@@ -1,0 +1,11 @@
+package com.ufrn.nei.almoxarifadoapi.exception;
+
+public class NotAvailableQuantity extends RuntimeException {
+    public NotAvailableQuantity() {
+        super("Não há quantidades disponíveis suficientes para este objeto.");
+    }
+
+    public NotAvailableQuantity(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/RestExceptionHandler.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/RestExceptionHandler.java
@@ -3,6 +3,8 @@ package com.ufrn.nei.almoxarifadoapi.infra;
 import com.ufrn.nei.almoxarifadoapi.exception.CreateEntityException;
 import com.ufrn.nei.almoxarifadoapi.exception.EntityNotFoundException;
 import com.ufrn.nei.almoxarifadoapi.exception.ItemNotActiveException;
+import com.ufrn.nei.almoxarifadoapi.exception.NotAvailableQuantity;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -16,48 +18,58 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 @ControllerAdvice
 public class RestExceptionHandler {
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<RestErrorMessage> handleItemNotFoundException(EntityNotFoundException exception,
-                                                                  HttpServletRequest request) {
-        log.info("API ERROR - ", exception);
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
-    }
+        @ExceptionHandler(EntityNotFoundException.class)
+        public ResponseEntity<RestErrorMessage> handleItemNotFoundException(EntityNotFoundException exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
+                return ResponseEntity
+                                .status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
+        }
 
-    @ExceptionHandler(CreateEntityException.class)
-    public ResponseEntity<RestErrorMessage> handleCreateEntityException(CreateEntityException exception,
-                                                                        HttpServletRequest request) {
-        log.info("API ERROR - ", exception);
+        @ExceptionHandler(CreateEntityException.class)
+        public ResponseEntity<RestErrorMessage> handleCreateEntityException(CreateEntityException exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
-    }
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
+        }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<RestErrorMessage> handleMethodArgumentNotValid(MethodArgumentNotValidException exception,
-                                                                         HttpServletRequest request) {
-        log.info("API ERROR - ", exception);
+        @ExceptionHandler(MethodArgumentNotValidException.class)
+        public ResponseEntity<RestErrorMessage> handleMethodArgumentNotValid(MethodArgumentNotValidException exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, "Campo(s) invalido(s)"));
-    }
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, "Campo(s) invalido(s)"));
+        }
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<RestErrorMessage> handleHttpMessageNotReadableException(HttpMessageNotReadableException exception,
-                                                                            HttpServletRequest request) {
-        log.info("API ERROR - ", exception);
+        @ExceptionHandler(HttpMessageNotReadableException.class)
+        public ResponseEntity<RestErrorMessage> handleHttpMessageNotReadableException(
+                        HttpMessageNotReadableException exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, "Campo(s) invalido(s)"));
-    }
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, "Campo(s) invalido(s)"));
+        }
 
-    @ExceptionHandler(ItemNotActiveException.class)
-    public ResponseEntity<RestErrorMessage> handleItemNotActiveException(ItemNotActiveException exception,
-                                                                         HttpServletRequest request) {
-        log.info("API ERROR - ", exception);
+        @ExceptionHandler(ItemNotActiveException.class)
+        public ResponseEntity<RestErrorMessage> handleItemNotActiveException(ItemNotActiveException exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
-    }
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
+        }
+
+        @ExceptionHandler(NotAvailableQuantity.class)
+        public ResponseEntity<RestErrorMessage> handleQuantityNotAvailableToLend(NotAvailableQuantity exception,
+                        HttpServletRequest request) {
+                log.info("API ERROR - ", exception);
+
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                                .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, exception.getMessage()));
+        }
 }

--- a/src/main/resources/db/migration/V4__ItemQuantityColumns.sql
+++ b/src/main/resources/db/migration/V4__ItemQuantityColumns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE Itens 
+ADD COLUMN quantidade_disponiveis integer NOT NULL default 1;
+
+ALTER TABLE Itens
+ADD COLUMN quantidade_emprestados integer NOT NULL default 1;
+
+ALTER TABLE Itens
+DROP COLUMN disponivel;

--- a/src/main/resources/db/migration/V5__EmailConstraint.sql
+++ b/src/main/resources/db/migration/V5__EmailConstraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Usuarios
+ADD CONSTRAINT unique_email UNIQUE (email);

--- a/src/test/java/com/ufrn/nei/almoxarifadoapi/service/ItemServiceTest.java
+++ b/src/test/java/com/ufrn/nei/almoxarifadoapi/service/ItemServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.ufrn.nei.almoxarifadoapi.dto.item.ItemCreateDTO;
 import com.ufrn.nei.almoxarifadoapi.dto.item.ItemResponseDTO;
+import com.ufrn.nei.almoxarifadoapi.dto.item.ItemUpdateDTO;
 import com.ufrn.nei.almoxarifadoapi.dto.mapper.ItemMapper;
 import com.ufrn.nei.almoxarifadoapi.entity.ItemEntity;
 import com.ufrn.nei.almoxarifadoapi.entity.RecordEntity;
@@ -37,9 +38,9 @@ public class ItemServiceTest {
 
     @BeforeEach
     void setup() {
-        items.add(new ItemEntity(null, "Cadeira", 202012L, true, Timestamp.valueOf(LocalDateTime.now()),
+        items.add(new ItemEntity(null, "Cadeira", 202012L, 100, 1, Timestamp.valueOf(LocalDateTime.now()),
                 Timestamp.valueOf(LocalDateTime.now()), true, new ArrayList<RecordEntity>()));
-        items.add(new ItemEntity(null, "Mesa", 202013L, true, Timestamp.valueOf(LocalDateTime.now()),
+        items.add(new ItemEntity(null, "Mesa", 202013L, 45, 22, Timestamp.valueOf(LocalDateTime.now()),
                 Timestamp.valueOf(LocalDateTime.now()), true, new ArrayList<RecordEntity>()));
         MockitoAnnotations.openMocks(this);
     }
@@ -60,7 +61,7 @@ public class ItemServiceTest {
     @DisplayName("Deve cadastrar Item corretamente")
     void createItemTest() {
         ItemEntity item = items.get(0);
-        ItemCreateDTO itemDTO = new ItemCreateDTO(item.getName(), item.getItemTagging());
+        ItemCreateDTO itemDTO = new ItemCreateDTO(item.getName(), item.getItemTagging(), item.getQuantityAvailable());
 
         Mockito.when(itemRepository.save(item)).thenReturn(item);
         ItemResponseDTO response = itemService.createItem(itemDTO);
@@ -75,8 +76,7 @@ public class ItemServiceTest {
     void deleteItemFailureTest() {
         EntityNotFoundException validate = assertThrows(
                 EntityNotFoundException.class,
-                () -> itemService.deleteItem(3L)
-        );
+                () -> itemService.deleteItem(3L));
 
         assertEquals("Item não encontrado com id=3", validate.getMessage());
     }


### PR DESCRIPTION
# Descrição

- Novas colunas de "quantidade disponíveis" e "quantidade emprestados" são adicionadas para termos controle sobre o estoque, e a coluna "disponível" é removida por ser desnecessária;
- Alterações foram feitas nos DTOs para suportar a nova adição;
- Criação de métodos no ItemService para gerenciar a adição e remoção dos valores dessas colunas. No total, 2 métodos foram criados, 1 para aumentar a quantidade de emprestados e diminuir de disponíveis e 1 que faz o oposto;
- Criação de uma rota PUT `api/v1/itens/lend/{id}`, que envia um objeto JSON `QuantityUpdateDTO` para executar as operações do Service.
   - Os métodos do Service podem e *devem* ser usados em conjunto com as funcionalidades que da entidade `Record`, para que o futuro RecordService não acesse a tabela de Itens e a manipulação seja feita somente por ItemService.
   - Não é recomendado que seja usada a rota `api/v1/itens/lend/{id}` para não fazer requisições e possivelmente bagunçar os dados; por outro lado, é possível deixar a rota no ar ainda e retirá-la no futuro.

## Tipo de alteração

- [ ] Correção de bug
- [x] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Criação de novos testes
- [ ] Outro (especifique)

**Especifique**: 

## Checklist

- [x] Minhas alterações foram testadas
- [x] Minhas alterações não introduzem novos problemas
- [x] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

NA

### Comentários adicionais

NA
