### PR TITLE
Rodrigo/refactor: Definir uma role padrão para a criação de novos usuários

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/user/UserCreateDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/user/UserCreateDTO.java
@@ -24,20 +24,18 @@ public class UserCreateDTO {
     @NotBlank
     @Size(min = 5)
     private String password;
-    @Positive
-    private Long roleId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserCreateDTO that = (UserCreateDTO) o;
-        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(password, that.password) && Objects.equals(roleId, that.roleId);
+        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(password, that.password);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, email, password, roleId);
+        return Objects.hash(name, email, password);
     }
 
     @Override
@@ -46,7 +44,6 @@ public class UserCreateDTO {
                 "name='" + name + '\'' +
                 ", email='" + email + '\'' +
                 ", password='" + password + '\'' +
-                ", idRole=" + roleId +
                 '}';
     }
 }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/repository/RoleRepository.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/repository/RoleRepository.java
@@ -4,6 +4,9 @@ import com.ufrn.nei.almoxarifadoapi.entity.RoleEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RoleRepository extends JpaRepository<RoleEntity, Long> {
+    Optional<RoleEntity> findByRole(String role);
 }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/service/RoleService.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/service/RoleService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -31,6 +32,11 @@ public class RoleService {
         RoleEntity role = roleRepository.findById(id).orElseThrow(
                 () -> new RuntimeException(String.format("Role não encontrada com o id: %d", id)));
         return role;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RoleEntity> findByRoleName(String role) {
+        return roleRepository.findByRole(role);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/service/RoleService.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/service/RoleService.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Slf4j

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/service/UserService.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/service/UserService.java
@@ -29,11 +29,9 @@ public class UserService {
     public UserEntity save(UserCreateDTO createDTO) {
         UserEntity user = UserMapper.toUser(createDTO);
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        RoleEntity role = roleService.findById(createDTO.getRoleId());
+        RoleEntity role = getRoleUser();
 
-        if (role != null) {
-            user.setRole(role);
-        }
+        user.setRole(role);
 
         userRepository.save(user);
 
@@ -84,4 +82,14 @@ public class UserService {
 
         user.setActive(false);
     }
+
+    // Método(s) Auxiliar(es)
+    private RoleEntity getRoleUser() {
+        final String ROLE_USER = "ROLE_USER";
+
+        return roleService.findByRoleName(ROLE_USER).orElseThrow(
+                () -> new EntityNotFoundException("Não foi possível encontrar a role de usuários")
+        );
+    }
+
 }


### PR DESCRIPTION
# Descrição

Definir a role de usuário `ROLE_USER` como a padrão quando algum usuário for criado

## Tipo de alteração

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Criação de novos testes
- [X] Outro (especifique)

**Especifique**: Mudar a forma de funcionamento de uma funcionalidade 

## Checklist

- [X] Minhas alterações foram testadas
- [X] Minhas alterações não introduzem novos problemas
- [X] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

Informe a issues relacionada a essa alteração: NA

### Comentários adicionais

Essa mudança foi feita com a finalidade de aumentar a segurança do sistema, evitando que usuários não autorizados sejam criados como administradores. Como a quantidade de administradores será menor quando comparado a quantidade de usuários simples, é preferível que todas as contas sejam criadas como usuários simples e a administração seja definida manualmente no banco de dados, mudando a role de `ROLE_USER` para `ROLE_ADMIN`.