### PR TITLE
Rodrigo/fix: Tratar exceção token JWT

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/config/SpringSecurityConfig.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/config/SpringSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ufrn.nei.almoxarifadoapi.config;
 
+import com.ufrn.nei.almoxarifadoapi.infra.jwt.JwtAuthenticationEntryPoint;
 import com.ufrn.nei.almoxarifadoapi.infra.jwt.JwtAuthorizationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,8 @@ public class SpringSecurityConfig {
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 ).addFilterBefore(
                         jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class
+                ).exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
                 )
                 .build();
     }

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.ufrn.nei.almoxarifadoapi.infra.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ufrn.nei.almoxarifadoapi.infra.RestErrorMessage;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info("Http Status 401 {}", authException.getMessage());
+
+        // Configurar o cabeçalho e o corpo da resposta
+        response.setHeader("www-authenticate", "Bearer realm='/api/v1/auth'");
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        ObjectMapper objectMapper = new ObjectMapper();
+        RestErrorMessage error = new RestErrorMessage(request, HttpStatus.UNAUTHORIZED, "Error relacionado ao Token Jwt");
+
+        String jsonResponse = objectMapper.writeValueAsString(error);
+
+        // Escrever o corpo da resposta
+        response.getWriter().write(jsonResponse);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // Definir manualmente o status HTTP
+
+        // Limpar o buffer e enviar a resposta
+        response.flushBuffer();
+    }
+}


### PR DESCRIPTION
# Descrição

Caso o Token JWT do usuário esteja nulo, inválido, expirado ou vazio a API irá retornar o erro 401 e o template de mensagens de erro. 

## Tipo de alteração

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Criação de novos testes
- [X] Outro (especifique)

**Especifique**: Resolver tratamento de exceção

## Checklist

- [X] Minhas alterações foram testadas
- [X] Minhas alterações não introduzem novos problemas
- [X] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

Informe a issues relacionada a essa alteração: NA

### Comentários adicionais

NA
