### PR TITLE
Rodrigo/feat: Configurar CORS

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/config/SpringSecurityConfig.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/config/SpringSecurityConfig.java
@@ -13,7 +13,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import java.util.Arrays;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
@@ -27,6 +32,7 @@ public class SpringSecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+                .cors(cors -> cors.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 antMatcher(HttpMethod.POST, "/api/v1/users"),
@@ -59,5 +65,16 @@ public class SpringSecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
# Descrição

Configurar CORS para receber requisições de domínios externos.

## Tipo de alteração

- [ ] Correção de bug
- [X] Nova funcionalidade
- [ ] Alteração na documentação
- [ ] Criação de novos testes
- [ ] Outro (especifique)

**Especifique**: 

## Checklist

- [X] Minhas alterações foram testadas
- [X] Minhas alterações não introduzem novos problemas
- [X] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

Informe a issues relacionada a essa alteração: NA

### Comentários adicionais

Por enquanto o CORS está configurado para receber requisições de qualquer domínio (por não existir ainda o deploy do front), métodos e cabeçalhos, entretanto, para garantir maior segurança após o deploy do front é importante restringir esse três campos.