### PR TITLE
Bug: Quantidade mínima do estoque

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/OperationController.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/OperationController.java
@@ -33,6 +33,7 @@ public class OperationController {
         @Operation(summary = "Criar registro de consumo.",
                 description = "Consumirá um item. Requsição exige o uso de um bearer token. Acesso restrito a role='ADMIN'.",
                 security = @SecurityRequirement(name = "security"),
+                deprecated = true,
                 responses = {
                         @ApiResponse(responseCode = "200", description = "Consumo criado com sucesso.",
                                 content = @Content(mediaType = "application/json", schema = @Schema(implementation = RecordResponseDTO.class))),

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemCreateDTO.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/dto/item/ItemCreateDTO.java
@@ -22,7 +22,7 @@ public class ItemCreateDTO {
     @Positive
     private int quantity;
     @PositiveOrZero
-    private Integer idealAmount = 0;
+    private Integer minimumStockLevel = 0;
     @NotBlank
     private String type;
     @PositiveOrZero


### PR DESCRIPTION
# Descrição

Foi resolvido o bug que não adicionava a quantidade mínima do estoque ao criar item. E tornar o endpoint `POST api/v1/operacoes/consumo` depreciado.

## Tipo de alteração

- [X] Correção de bug
- [ ] Nova funcionalidade
- [X] Alteração na documentação
- [ ] Criação de novos testes
- [ ] Outro (especifique)

**Especifique**: 

## Checklist

- [X] Minhas alterações foram testadas
- [X] Minhas alterações não introduzem novos problemas
- [X] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

Informe a issues relacionada a essa alteração: NA

### Comentários adicionais

NA