### PR TITLE
Feat: Verificar se usuário está ativo ao autenticar e novas exceções

### DIFF
--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/AuthenticationController.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/AuthenticationController.java
@@ -30,9 +30,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.authentication.*;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -69,21 +67,14 @@ public class AuthenticationController {
   public ResponseEntity<?> authenticate(@RequestBody @Valid UserLoginDTO login, HttpServletRequest request) {
     log.info("Processo de autenticação pelo login {}", login.getEmail());
 
-    try {
-      UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-          login.getEmail(), login.getPassword());
+    UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+            login.getEmail(), login.getPassword());
 
-      authenticationManager.authenticate(authenticationToken);
+    authenticationManager.authenticate(authenticationToken);
 
-      JwtToken token = detailsService.getTokenAuthenticated(login.getEmail());
+    JwtToken token = detailsService.getTokenAuthenticated(login.getEmail());
 
-      return ResponseEntity.status(HttpStatus.OK).body(token);
-    } catch (AuthenticationException ex) {
-      log.warn("Bad credentials from username {}", login.getEmail());
-    }
-
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new RestErrorMessage(request, HttpStatus.BAD_REQUEST, "Credenciais inválidas"));
+    return ResponseEntity.status(HttpStatus.OK).body(token);
   }
 
   @Operation(summary = "Esqueceu a senha", description = "Solicita um token de redefinição de senha no e-mail", responses = {

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/AuthenticationController.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/controller/AuthenticationController.java
@@ -61,7 +61,10 @@ public class AuthenticationController {
   @Operation(summary = "Autenticar na API", description = "Recurso de autenticação na API", responses = {
       @ApiResponse(responseCode = "200", description = "Autenticação realizada com sucesso e retorno de um Bearer Token", content = @Content(mediaType = "application/json", schema = @Schema(implementation = JwtToken.class))),
       @ApiResponse(responseCode = "400", description = "Credenciais inválidas", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class))),
-      @ApiResponse(responseCode = "422", description = "Campo(s) Inválido(s)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
+      @ApiResponse(responseCode = "403", description = "Usuário está inativo", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class))),
+      @ApiResponse(responseCode = "404", description = "Usuário não existe", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class))),
+      @ApiResponse(responseCode = "422", description = "Campo(s) Inválido(s)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class))),
+      @ApiResponse(responseCode = "500", description = "Erro desconhecido ao realizar autenticação", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RestErrorMessage.class)))
   })
   @PostMapping
   public ResponseEntity<?> authenticate(@RequestBody @Valid UserLoginDTO login, HttpServletRequest request) {

--- a/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/jwt/JwtUserDetailsService.java
+++ b/src/main/java/com/ufrn/nei/almoxarifadoapi/infra/jwt/JwtUserDetailsService.java
@@ -5,6 +5,7 @@ import com.ufrn.nei.almoxarifadoapi.exception.EntityNotFoundException;
 import com.ufrn.nei.almoxarifadoapi.repository.UserRepository;
 import com.ufrn.nei.almoxarifadoapi.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -21,7 +22,12 @@ public class JwtUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         UserEntity user = userRepository.findByEmail(username).orElseThrow(
-                EntityNotFoundException::new);
+                () -> new EntityNotFoundException("Usuário não encontrado.")
+        );
+
+        if (!user.getActive()) {
+            throw new DisabledException("Usuário inativo");
+        }
 
         return new JwtUserDetails(user);
     }


### PR DESCRIPTION
# Descrição

Verificar se o usuário está ativo ao relizar a autenticação, se não estiver ativo lançará a exceção DisabledException.
Foi removido também o try-catch do controller de autenticar, o tratamento de exceção foi movido para o RestExceptionHandler.

## Tipo de alteração

- [X] Correção de bug
- [X] Nova funcionalidade
- [X] Alteração na documentação
- [ ] Criação de novos testes
- [ ] Outro (especifique)

**Especifique**: 

## Checklist

- [X] Minhas alterações foram testadas
- [X] Minhas alterações não introduzem novos problemas
- [X] Minhas alterações estão de acordo com os padrões do projeto

## Issue relacionada (opcional)

NA

### Comentários adicionais

As exeções `DisabledException` e `EntityNotFoundException` estão sendo tratadas como `instaceof` porque ao lança-las ao tentar realizar a autenticação no `JwtUserDetailsService` vem a exceção `InternalAuthenticationServiceException` como sendo principal que é causada por `DisabledException` e `EntityNotFoundException`. Não sei porque isso acontece. 
